### PR TITLE
fix: support scala 3.6.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,8 @@ ThisBuild / credentials += Credentials(
 ThisBuild / publishMavenStyle := true
 
 ThisBuild / version            := "2.1.0"
-ThisBuild / scalaVersion       := "3.6.2"
-ThisBuild / crossScalaVersions := Seq("3.6.2", "2.13.14", "2.12.20")
+ThisBuild / scalaVersion       := "3.6.3"
+ThisBuild / crossScalaVersions := Seq("3.6.3", "2.13.14", "2.12.20")
 
 usePgpKeyHex("F20744182C3B3EB4FF46C78AB97796F0040A9891")
 

--- a/src/main/scala-3/be/broij/zarrow/ZArrow.scala
+++ b/src/main/scala-3/be/broij/zarrow/ZArrow.scala
@@ -27,11 +27,7 @@ opaque type ZArrow[-I, -R, +E, +O] = I => ZIO[R, E, O]
 
 object ZArrow:
 
-  /**
-   * Accesses the specified ZArrow in the ZIO environment.
-   */
-  def service[I: Tag, R: Tag, E: Tag, O: Tag] =
-    ZIO.service[ZArrow[I, R, E, O]]
+  export zlayer.Ops.*
 
   /**
    * A `ZArrow` that always maps to a `ZIO` that succeeds with a unit value.
@@ -148,11 +144,8 @@ object ZArrow:
 
 extension [I, R, E, O](zArrow: ZArrow[I, R, E, O])
 
-  /**
-   * Constructs a ZLayer from this `ZArrow`.
-   */
-  def layer(using tag: Tag[ZArrow[I, R, E, O]]): ULayer[ZArrow[I, R, E, O]] =
-    ZLayer.succeed(zArrow)
+  private def zLayerOps = zlayer.Ops(zArrow)
+  export zLayerOps.*
 
   /**
    * Applies this `ZArrow` to the input `in`, returning the `ZIO` that it is

--- a/src/main/scala-3/be/broij/zarrow/ZLayer.scala
+++ b/src/main/scala-3/be/broij/zarrow/ZLayer.scala
@@ -1,0 +1,19 @@
+package be.broij.zarrow.zlayer
+
+import be.broij.zarrow.ZArrow
+import scala.Predef.{identity => id, summon}
+import zio._
+
+final case class Ops[I, R, E, O](zArrow: ZArrow[I, R, E, O]):
+  /**
+   * Constructs a ZLayer from this `ZArrow`.
+   */
+  def layer(using tag: Tag[ZArrow[I, R, E, O]]): ULayer[ZArrow[I, R, E, O]] =
+    ZLayer.succeed(zArrow)
+
+object Ops:
+  /**
+   * Accesses the specified ZArrow in the ZIO environment.
+   */
+  def service[I: Tag, R: Tag, E: Tag, O: Tag] =
+    ZIO.service[ZArrow[I, R, E, O]]


### PR DESCRIPTION
Move ZLayer ops to another package to avoid runtime issues with zio and opaque types in scala 3.6.3